### PR TITLE
Change dummy variable in Grid to tensor instead of parameter.

### DIFF
--- a/nerfacc/grid.py
+++ b/nerfacc/grid.py
@@ -66,7 +66,7 @@ class Grid(nn.Module):
 
     def __init__(self, *args, **kwargs):
         super().__init__()
-        self._dummy = torch.nn.Parameter(torch.empty(0))
+        self.register_buffer("_dummy", torch.empty(0), persistent=False)
 
     @property
     def device(self) -> torch.device:


### PR DESCRIPTION
The dummy variable in Grid is defined as parameter, which is not used in training but may cause "unused parameter error" in some frameworks (for example when using DDP in pytorch-lightning). 