### PR TITLE
Add support mip nerf in training example

### DIFF
--- a/examples/datasets/nerf_synthetic.py
+++ b/examples/datasets/nerf_synthetic.py
@@ -213,15 +213,6 @@ class SubjectLoader(torch.utils.data.Dataset):
             directions, dim=-1, keepdims=True
         )
 
-        if self.training:
-            origins = torch.reshape(origins, (num_rays, 3))
-            viewdirs = torch.reshape(viewdirs, (num_rays, 3))
-            rgba = torch.reshape(rgba, (num_rays, 4))
-        else:
-            origins = torch.reshape(origins, (self.HEIGHT, self.WIDTH, 3))
-            viewdirs = torch.reshape(viewdirs, (self.HEIGHT, self.WIDTH, 3))
-            rgba = torch.reshape(rgba, (self.HEIGHT, self.WIDTH, 4))
-
         if self.get_radii:
             camera_dirs_cornor = F.pad(
                 torch.stack(
@@ -252,6 +243,17 @@ class SubjectLoader(torch.utils.data.Dataset):
                 torch.ones(origins.shape[0], 1, device=self.images.device)
                 * radii_value
             )
+
+        if self.training:
+            origins = torch.reshape(origins, (num_rays, 3))
+            viewdirs = torch.reshape(viewdirs, (num_rays, 3))
+            rgba = torch.reshape(rgba, (num_rays, 4))
+            radii = torch.reshape(radii, (num_rays, 1))
+        else:
+            origins = torch.reshape(origins, (self.HEIGHT, self.WIDTH, 3))
+            viewdirs = torch.reshape(viewdirs, (self.HEIGHT, self.WIDTH, 3))
+            rgba = torch.reshape(rgba, (self.HEIGHT, self.WIDTH, 4))
+            radii = torch.reshape(radii, (self.HEIGHT, self.WIDTH, 1))
 
         rays = Rays(origins=origins, viewdirs=viewdirs, radii=radii)
 

--- a/examples/datasets/utils.py
+++ b/examples/datasets/utils.py
@@ -4,7 +4,7 @@ Copyright (c) 2022 Ruilong Li, UC Berkeley.
 
 import collections
 
-Rays = collections.namedtuple("Rays", ("origins", "viewdirs"))
+Rays = collections.namedtuple("Rays", ("origins", "viewdirs", "radii"))
 
 
 def namedtuple_map(fn, tup):

--- a/examples/mip_utils.py
+++ b/examples/mip_utils.py
@@ -1,0 +1,164 @@
+"""
+Copyright (c) 2022 Ruilong Li, UC Berkeley.
+"""
+
+import random
+from typing import Optional
+
+import numpy as np
+import torch
+from datasets.utils import Rays, namedtuple_map
+
+from nerfacc import OccupancyGrid, ray_marching, rendering
+
+
+def set_random_seed(seed):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+
+# gaussion computation from Nerf-Factory
+def lift_gaussian(d, t_mean, t_var, r_var):
+
+    mean = d[..., None, :] * t_mean[..., None]
+
+    d_mag_sq = torch.sum(d**2, dim=-1, keepdim=True)
+    thresholds = torch.ones_like(d_mag_sq) * 1e-10
+    d_mag_sq = torch.fmax(d_mag_sq, thresholds)
+
+    d_outer_diag = d**2
+    null_outer_diag = 1 - d_outer_diag / d_mag_sq
+    t_cov_diag = t_var[..., None] * d_outer_diag[..., None, :]
+    xy_cov_diag = r_var[..., None] * null_outer_diag[..., None, :]
+    cov_diag = t_cov_diag + xy_cov_diag
+
+    return mean, cov_diag
+
+
+def conical_frustum_to_gaussian(d, t0, t1, radius):
+
+    mu = (t0 + t1) / 2
+    hw = (t1 - t0) / 2
+    t_mean = mu + (2 * mu * hw**2) / (3 * mu**2 + hw**2)
+    t_var = (hw**2) / 3 - (4 / 15) * (
+        (hw**4 * (12 * mu**2 - hw**2)) / (3 * mu**2 + hw**2) ** 2
+    )
+    r_var = radius**2 * (
+        (mu**2) / 4
+        + (5 / 12) * hw**2
+        - 4 / 15 * (hw**4) / (3 * mu**2 + hw**2)
+    )
+
+    return lift_gaussian(d, t_mean, t_var, r_var)
+
+
+def cylinder_to_gaussian(d, t0, t1, radius):
+
+    t_mean = (t0 + t1) / 2
+    r_var = radius**2 / 4
+    t_var = (t1 - t0) ** 2 / 12
+
+    return lift_gaussian(d, t_mean, t_var, r_var)
+
+
+def cast_rays(t_starts, t_ends, origins, directions, radii, ray_shape):
+    if ray_shape == "cone":
+        gaussian_fn = conical_frustum_to_gaussian
+    elif ray_shape == "cylinder":
+        gaussian_fn = cylinder_to_gaussian
+    else:
+        assert False
+    means, covs = gaussian_fn(directions, t_starts, t_ends, radii)
+    means = means + origins[..., None, :]
+    return means, covs
+
+
+def render_image(
+    # scene
+    radiance_field: torch.nn.Module,
+    occupancy_grid: OccupancyGrid,
+    rays: Rays,
+    scene_aabb: torch.Tensor,
+    # rendering options
+    near_plane: Optional[float] = None,
+    far_plane: Optional[float] = None,
+    render_step_size: float = 1e-3,
+    render_bkgd: Optional[torch.Tensor] = None,
+    cone_angle: float = 0.0,
+    alpha_thre: float = 0.0,
+    # test options
+    test_chunk_size: int = 8192,
+    # only useful for dnerf
+    ray_shape: str = "cylinder",
+):
+    """Render the pixels of an image."""
+    rays_shape = rays.origins.shape
+    if len(rays_shape) == 3:
+        height, width, _ = rays_shape
+        num_rays = height * width
+        rays = namedtuple_map(
+            lambda r: r.reshape([num_rays] + list(r.shape[2:])), rays
+        )
+    else:
+        num_rays, _ = rays_shape
+
+    def sigma_fn(t_starts, t_ends, ray_indices):
+        print(t_starts, t_ends)
+        print(t_starts.shape)
+        print(ray_indices.shape)
+        assert False
+        t_origins = rays_o[ray_indices]  # (n_samples, 3)
+        t_dirs = rays_d[ray_indices]  # (n_samples, 3)
+        t_radii = rays_radii[ray_indices] # (n_samples,)
+        mean, cov = cast_rays(t_starts, t_ends, t_origins, t_dirs, t_radii, ray_shape)
+        return radiance_field.query_density(mean, cov)
+
+    def rgb_sigma_fn(t_starts, t_ends, ray_indices):
+        ray_indices = ray_indices.long()
+        t_origins = chunk_rays.origins[ray_indices]
+        t_dirs = chunk_rays.viewdirs[ray_indices]
+        mean, cov = cast_rays(t_starts, t_ends, t_origins, t_dirs, t_radii, ray_shape)
+        return radiance_field(mean, cov, t_dirs)
+
+    results = []
+    chunk = (
+        torch.iinfo(torch.int32).max
+        if radiance_field.training
+        else test_chunk_size
+    )
+    for i in range(0, num_rays, chunk):
+        chunk_rays = namedtuple_map(lambda r: r[i : i + chunk], rays)
+        ray_indices, t_starts, t_ends = ray_marching(
+            chunk_rays.origins,
+            chunk_rays.viewdirs,
+            scene_aabb=scene_aabb,
+            grid=occupancy_grid,
+            sigma_fn=sigma_fn,
+            near_plane=near_plane,
+            far_plane=far_plane,
+            render_step_size=render_step_size,
+            stratified=radiance_field.training,
+            cone_angle=cone_angle,
+            alpha_thre=alpha_thre,
+        )
+        rgb, opacity, depth = rendering(
+            t_starts,
+            t_ends,
+            ray_indices,
+            n_rays=chunk_rays.origins.shape[0],
+            rgb_sigma_fn=rgb_sigma_fn,
+            render_bkgd=render_bkgd,
+        )
+        chunk_results = [rgb, opacity, depth, len(t_starts)]
+        results.append(chunk_results)
+    colors, opacities, depths, n_rendering_samples = [
+        torch.cat(r, dim=0) if isinstance(r[0], torch.Tensor) else r
+        for r in zip(*results)
+    ]
+    return (
+        colors.view((*rays_shape[:-1], -1)),
+        opacities.view((*rays_shape[:-1], -1)),
+        depths.view((*rays_shape[:-1], -1)),
+        sum(n_rendering_samples),
+    )

--- a/examples/mip_utils.py
+++ b/examples/mip_utils.py
@@ -20,7 +20,6 @@ def set_random_seed(seed):
 
 # gaussion computation from Nerf-Factory
 def lift_gaussian(d, t_mean, t_var, r_var):
-
     mean = d * t_mean
 
     d_mag_sq = torch.sum(d**2, dim=-1, keepdim=True)

--- a/examples/train_mip_nerf.py
+++ b/examples/train_mip_nerf.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
         ).item()
 
     # setup the radiance field we want to train.
-    max_steps = 1 #50000
+    max_steps = 50000
     grad_scaler = torch.cuda.amp.GradScaler(1)
     radiance_field = MipNeRFRadianceField().to(device)
     optimizer = torch.optim.Adam(radiance_field.parameters(), lr=5e-4)

--- a/examples/train_mip_nerf.py
+++ b/examples/train_mip_nerf.py
@@ -6,6 +6,7 @@ import argparse
 import math
 import os
 import time
+import pathlib
 
 import imageio
 import numpy as np
@@ -23,6 +24,12 @@ if __name__ == "__main__":
     set_random_seed(42)
 
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--data_root",
+        type=str,
+        default=str(pathlib.Path.home() / "data"),
+        help="the root dir of the dataset",
+    )
     parser.add_argument(
         "--train_split",
         type=str,
@@ -119,7 +126,7 @@ if __name__ == "__main__":
     if args.scene == "garden":
         from datasets.nerf_360_v2 import SubjectLoader
 
-        data_root_fp = "/home/ruilongli/data/360_v2/"
+        data_root_fp = pathlib.Path(args.data_root) / "360_v2"
         target_sample_batch_size = 1 << 16
         train_dataset_kwargs = {"color_bkgd_aug": "random", "factor": 4}
         test_dataset_kwargs = {"factor": 4}
@@ -127,7 +134,7 @@ if __name__ == "__main__":
     else:
         from datasets.nerf_synthetic import SubjectLoader
 
-        data_root_fp = "/home/yaliu/NeRF-Factory/data/blender"
+        data_root_fp = pathlib.Path(args.data_root) / "nerf_synthetic"
         target_sample_batch_size = 1 << 16
         grid_resolution = 128
 
@@ -228,6 +235,7 @@ if __name__ == "__main__":
                 render_step_size=render_step_size,
                 render_bkgd=render_bkgd,
                 cone_angle=args.cone_angle,
+                ray_shape=args.ray_shape,
             )
             if n_rendering_samples == 0:
                 continue

--- a/examples/train_mip_nerf.py
+++ b/examples/train_mip_nerf.py
@@ -128,7 +128,7 @@ if __name__ == "__main__":
         from datasets.nerf_synthetic import SubjectLoader
 
         data_root_fp = "/home/yaliu/NeRF-Factory/data/blender"
-        target_sample_batch_size = 1 << 15
+        target_sample_batch_size = 1 << 16
         grid_resolution = 128
 
     train_dataset = SubjectLoader(
@@ -212,7 +212,6 @@ if __name__ == "__main__":
                 # compute occupancy
                 density = radiance_field.query_density(x, xcov)
                 return density * step_size
-                # return torch.ones_like(occ_rays.radii)
 
             # update occupancy grid
             occupancy_grid.every_n_step(step=step, occ_eval_fn=occ_eval_fn)

--- a/examples/train_mip_nerf.py
+++ b/examples/train_mip_nerf.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
         ).item()
 
     # setup the radiance field we want to train.
-    max_steps = 50000
+    max_steps = 1 #50000
     grad_scaler = torch.cuda.amp.GradScaler(1)
     radiance_field = MipNeRFRadianceField().to(device)
     optimizer = torch.optim.Adam(radiance_field.parameters(), lr=5e-4)
@@ -126,7 +126,7 @@ if __name__ == "__main__":
     if args.scene == "garden":
         from datasets.nerf_360_v2 import SubjectLoader
 
-        data_root_fp = pathlib.Path(args.data_root) / "360_v2"
+        data_root_fp = str(pathlib.Path(args.data_root) / "360_v2")
         target_sample_batch_size = 1 << 16
         train_dataset_kwargs = {"color_bkgd_aug": "random", "factor": 4}
         test_dataset_kwargs = {"factor": 4}
@@ -134,7 +134,7 @@ if __name__ == "__main__":
     else:
         from datasets.nerf_synthetic import SubjectLoader
 
-        data_root_fp = pathlib.Path(args.data_root) / "nerf_synthetic"
+        data_root_fp = str(pathlib.Path(args.data_root) / "nerf_synthetic")
         target_sample_batch_size = 1 << 16
         grid_resolution = 128
 
@@ -294,6 +294,7 @@ if __name__ == "__main__":
                             cone_angle=args.cone_angle,
                             # test options
                             test_chunk_size=args.test_chunk_size,
+                            ray_shape=args.ray_shape,
                         )
                         mse = F.mse_loss(rgb, pixels)
                         psnr = -10.0 * torch.log(mse) / np.log(10.0)

--- a/examples/train_mlp_dnerf.py
+++ b/examples/train_mlp_dnerf.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
         gamma=0.33,
     )
     # setup the dataset
-    data_root_fp = pathlib.Path(args.data_root) / "dnerf"
+    data_root_fp = str(pathlib.Path(args.data_root) / "dnerf")
     target_sample_batch_size = 1 << 16
     grid_resolution = 128
 

--- a/examples/train_mlp_dnerf.py
+++ b/examples/train_mlp_dnerf.py
@@ -25,6 +25,12 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "--data_root",
+        type=str,
+        default=str(pathlib.Path.home() / "data"),
+        help="the root dir of the dataset",
+    )
+    parser.add_argument(
         "--train_split",
         type=str,
         default="train",
@@ -91,7 +97,7 @@ if __name__ == "__main__":
         gamma=0.33,
     )
     # setup the dataset
-    data_root_fp = "/home/ruilongli/data/dnerf/"
+    data_root_fp = pathlib.Path(args.data_root) / "dnerf"
     target_sample_batch_size = 1 << 16
     grid_resolution = 128
 

--- a/examples/train_mlp_nerf.py
+++ b/examples/train_mlp_nerf.py
@@ -24,6 +24,12 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "--data_root",
+        type=str,
+        default=str(pathlib.Path.home() / "data"),
+        help="the root dir of the dataset",
+    )
+    parser.add_argument(
         "--train_split",
         type=str,
         default="trainval",
@@ -112,7 +118,7 @@ if __name__ == "__main__":
     if args.scene == "garden":
         from datasets.nerf_360_v2 import SubjectLoader
 
-        data_root_fp = "/home/ruilongli/data/360_v2/"
+        data_root_fp = pathlib.Path(args.data_root) / "360_v2"
         target_sample_batch_size = 1 << 16
         train_dataset_kwargs = {"color_bkgd_aug": "random", "factor": 4}
         test_dataset_kwargs = {"factor": 4}
@@ -120,7 +126,7 @@ if __name__ == "__main__":
     else:
         from datasets.nerf_synthetic import SubjectLoader
 
-        data_root_fp = "/home/yaliu/NeRF-Factory/data/blender"
+        data_root_fp = pathlib.Path(args.data_root) / "nerf_synthetic"
         target_sample_batch_size = 1 << 16
         grid_resolution = 128
 

--- a/examples/train_mlp_nerf.py
+++ b/examples/train_mlp_nerf.py
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     if args.scene == "garden":
         from datasets.nerf_360_v2 import SubjectLoader
 
-        data_root_fp = pathlib.Path(args.data_root) / "360_v2"
+        data_root_fp = str(pathlib.Path(args.data_root) / "360_v2")
         target_sample_batch_size = 1 << 16
         train_dataset_kwargs = {"color_bkgd_aug": "random", "factor": 4}
         test_dataset_kwargs = {"factor": 4}
@@ -126,7 +126,7 @@ if __name__ == "__main__":
     else:
         from datasets.nerf_synthetic import SubjectLoader
 
-        data_root_fp = pathlib.Path(args.data_root) / "nerf_synthetic"
+        data_root_fp = str(pathlib.Path(args.data_root) / "nerf_synthetic")
         target_sample_batch_size = 1 << 16
         grid_resolution = 128
 

--- a/examples/train_ngp_nerf.py
+++ b/examples/train_ngp_nerf.py
@@ -24,6 +24,12 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "--data_root",
+        type=str,
+        default=str(pathlib.Path.home() / "data"),
+        help="the root dir of the dataset",
+    )
+    parser.add_argument(
         "--train_split",
         type=str,
         default="trainval",
@@ -87,7 +93,7 @@ if __name__ == "__main__":
     if args.unbounded:
         from datasets.nerf_360_v2 import SubjectLoader
 
-        data_root_fp = "/home/ruilongli/data/360_v2/"
+        data_root_fp = pathlib.Path(args.data_root) / "360_v2"
         target_sample_batch_size = 1 << 20
         train_dataset_kwargs = {"color_bkgd_aug": "random", "factor": 4}
         test_dataset_kwargs = {"factor": 4}
@@ -95,7 +101,7 @@ if __name__ == "__main__":
     else:
         from datasets.nerf_synthetic import SubjectLoader
 
-        data_root_fp = "/home/yaliu/NeRF-Factory/data/blender"
+        data_root_fp = pathlib.Path(args.data_root) / "nerf_synthetic"
         target_sample_batch_size = 1 << 18
         grid_resolution = 128
 

--- a/examples/train_ngp_nerf.py
+++ b/examples/train_ngp_nerf.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     else:
         from datasets.nerf_synthetic import SubjectLoader
 
-        data_root_fp = "/home/ruilongli/data/nerf_synthetic/"
+        data_root_fp = "/home/yaliu/NeRF-Factory/data/blender"
         target_sample_batch_size = 1 << 18
         grid_resolution = 128
 

--- a/examples/train_ngp_nerf.py
+++ b/examples/train_ngp_nerf.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":
     if args.unbounded:
         from datasets.nerf_360_v2 import SubjectLoader
 
-        data_root_fp = pathlib.Path(args.data_root) / "360_v2"
+        data_root_fp = str(pathlib.Path(args.data_root) / "360_v2")
         target_sample_batch_size = 1 << 20
         train_dataset_kwargs = {"color_bkgd_aug": "random", "factor": 4}
         test_dataset_kwargs = {"factor": 4}
@@ -101,7 +101,7 @@ if __name__ == "__main__":
     else:
         from datasets.nerf_synthetic import SubjectLoader
 
-        data_root_fp = pathlib.Path(args.data_root) / "nerf_synthetic"
+        data_root_fp = str(pathlib.Path(args.data_root) / "nerf_synthetic")
         target_sample_batch_size = 1 << 18
         grid_resolution = 128
 

--- a/examples/train_ngp_nerf_proposal.py
+++ b/examples/train_ngp_nerf_proposal.py
@@ -208,14 +208,14 @@ if __name__ == "__main__":
     if args.unbounded:
         from datasets.nerf_360_v2 import SubjectLoader
 
-        data_root_fp = pathlib.Path(args.data_root) / "360_v2"
+        data_root_fp = str(pathlib.Path(args.data_root) / "360_v2")
         target_sample_batch_size = 1 << 20
         train_dataset_kwargs = {"color_bkgd_aug": "random", "factor": 4}
         test_dataset_kwargs = {"factor": 4}
     else:
         from datasets.nerf_synthetic import SubjectLoader
 
-        data_root_fp = pathlib.Path(args.data_root) / "nerf_synthetic"
+        data_root_fp = str(pathlib.Path(args.data_root) / "nerf_synthetic")
         target_sample_batch_size = 1 << 18
 
     train_dataset = SubjectLoader(

--- a/examples/train_ngp_nerf_proposal.py
+++ b/examples/train_ngp_nerf_proposal.py
@@ -139,6 +139,12 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "--data_root",
+        type=str,
+        default=str(pathlib.Path.home() / "data"),
+        help="the root dir of the dataset",
+    )
+    parser.add_argument(
         "--train_split",
         type=str,
         default="trainval",
@@ -202,14 +208,14 @@ if __name__ == "__main__":
     if args.unbounded:
         from datasets.nerf_360_v2 import SubjectLoader
 
-        data_root_fp = "/home/ruilongli/data/360_v2/"
+        data_root_fp = pathlib.Path(args.data_root) / "360_v2"
         target_sample_batch_size = 1 << 20
         train_dataset_kwargs = {"color_bkgd_aug": "random", "factor": 4}
         test_dataset_kwargs = {"factor": 4}
     else:
         from datasets.nerf_synthetic import SubjectLoader
 
-        data_root_fp = "/home/ruilongli/data/nerf_synthetic/"
+        data_root_fp = pathlib.Path(args.data_root) / "nerf_synthetic"
         target_sample_batch_size = 1 << 18
 
     train_dataset = SubjectLoader(


### PR DESCRIPTION
Hi, @liruilong940607,

Thanks for your awesome work!

I just add the support for training the mip nerf (kind of) with nerfacc based on your discussion at #88. I did a quick test for the lego scene with 1 t4 and this is the full logs:

```
elapsed_time=1.76s | step=0 | loss=0.07456 | alive_ray_mask=64 | n_rendering_samples=10341 | num_rays=64 |
elapsed_time=675.89s | step=5000 | loss=0.00614 | alive_ray_mask=1972 | n_rendering_samples=65941 | num_rays=6340 |
elapsed_time=1436.05s | step=10000 | loss=0.00325 | alive_ray_mask=2624 | n_rendering_samples=62479 | num_rays=8388 |
elapsed_time=2252.93s | step=15000 | loss=0.00259 | alive_ray_mask=3201 | n_rendering_samples=65802 | num_rays=10022 |
elapsed_time=3095.50s | step=20000 | loss=0.00191 | alive_ray_mask=3379 | n_rendering_samples=65854 | num_rays=10483 |
elapsed_time=3944.66s | step=25000 | loss=0.00169 | alive_ray_mask=3569 | n_rendering_samples=66453 | num_rays=11441 |
elapsed_time=4818.70s | step=30000 | loss=0.00130 | alive_ray_mask=3888 | n_rendering_samples=65518 | num_rays=12459 |
elapsed_time=5703.86s | step=35000 | loss=0.00117 | alive_ray_mask=4004 | n_rendering_samples=65890 | num_rays=12501 |
elapsed_time=6595.80s | step=40000 | loss=0.00116 | alive_ray_mask=4163 | n_rendering_samples=66805 | num_rays=13105 |
elapsed_time=7495.55s | step=45000 | loss=0.00095 | alive_ray_mask=4178 | n_rendering_samples=66799 | num_rays=13154 |
elapsed_time=8396.90s | step=50000 | loss=0.00086 | alive_ray_mask=4242 | n_rendering_samples=67710 | num_rays=13257 |
100%|██████████| 200/200 [19:52<00:00,  5.96s/it]
evaluation: psnr_avg=33.62006133079529
```

The training time is pretty similar with vanilla nerf and the performance is almost same as well (which I do expect slightly better performance).

It would be nice if you can take a look at it when you are available!

Thank you in advance!

Btw, this pr also changes the dataset root dir to an argument for easier usage 😉 