### PR TITLE
fixed a hang bug in ray_marching

### DIFF
--- a/nerfacc/cuda/csrc/ray_marching.cu
+++ b/nerfacc/cuda/csrc/ray_marching.cu
@@ -59,11 +59,13 @@ inline __device__ __host__ float distance_to_next_voxel(
 inline __device__ __host__ float advance_to_next_voxel(
     const float t, const float dt_min,
     const float3 xyz, const float3 dir, const float3 inv_dir,
-    const float3 roi_min, const float3 roi_max, const int3 grid_res)
+    const float3 roi_min, const float3 roi_max, const int3 grid_res, const float far)
 {
     // Regular stepping (may be slower but matches non-empty space)
     float t_target = t + distance_to_next_voxel(
                              xyz, dir, inv_dir, roi_min, roi_max, grid_res);
+    
+    t_target = min(t_target, far);
     float _t = t;
     do
     {
@@ -166,7 +168,7 @@ __global__ void ray_marching_kernel(
             case ContractionType::AABB:
                 // no contraction
                 t_mid = advance_to_next_voxel(
-                    t_mid, dt_min, xyz, dir, inv_dir, roi_min, roi_max, grid_res);
+                    t_mid, dt_min, xyz, dir, inv_dir, roi_min, roi_max, grid_res, far);
                 dt = calc_dt(t_mid, cone_angle, dt_min, dt_max);
                 t0 = t_mid - dt * 0.5f;
                 t1 = t_mid + dt * 0.5f;


### PR DESCRIPTION
fixed a hang bug where t_target has inf value ( ray is parralel to plane ?) t_target should not be larger that far anyway

@tancik I found the hang bug - 
t_target got inf value. 
if we bound it by far - it fixes the issue.

This is related to https://github.com/nerfstudio-project/nerfstudio/issues/1152.

The problem is that I see that nerfstudio is incompatible with the newest version of nerfacc, so a work needs to be done in nerfstudio to upgrade nerfacc.
