### PR TITLE
feat(ci): switch caching to `actions/setup-python@v4`

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -19,10 +19,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.8.12"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
       - name: Install dependencies
         run: |
           pip install --upgrade --upgrade-strategy eager -e .[dev]


### PR DESCRIPTION
Changes made by this PR can be summarized as follows:

- Set the `cache` and `cache-dependency-path` argument of `actions/setup-python` to enable `pip` caching.
- Delete the redundant `actions/cache@v2` step.