### PR TITLE
Fix the link to train_mlp_nerf

### DIFF
--- a/docs/source/examples/vanilla.rst
+++ b/docs/source/examples/vanilla.rst
@@ -29,5 +29,5 @@ conducted on a single NVIDIA TITAN RTX GPU. The training memory footprint is abo
 | Ours  (Training time)| 58min | 53min | 46min   | 62min | 56min | 42min | 52min | 49min | 52min |
 +----------------------+-------+-------+---------+-------+-------+-------+-------+-------+-------+
 
-.. _`github repository`: : https://github.com/KAIR-BAIR/nerfacc/tree/76c0f9817da4c9c8b5ccf827eb069ee2ce854b75
+.. _`github repository`: https://github.com/KAIR-BAIR/nerfacc/blob/master/examples/train_mlp_nerf.py
 .. _`vanilla Nerf`: https://arxiv.org/abs/2003.08934

--- a/docs/source/examples/vanilla.rst
+++ b/docs/source/examples/vanilla.rst
@@ -29,5 +29,5 @@ conducted on a single NVIDIA TITAN RTX GPU. The training memory footprint is abo
 | Ours  (Training time)| 58min | 53min | 46min   | 62min | 56min | 42min | 52min | 49min | 52min |
 +----------------------+-------+-------+---------+-------+-------+-------+-------+-------+-------+
 
-.. _`github repository`: https://github.com/KAIR-BAIR/nerfacc/blob/master/examples/train_mlp_nerf.py
+.. _`github repository`: https://github.com/KAIR-BAIR/nerfacc/blob/76c0f9817da4c9c8b5ccf827eb069ee2ce854b75/examples/train_mlp_nerf.py
 .. _`vanilla Nerf`: https://arxiv.org/abs/2003.08934


### PR DESCRIPTION
The extra `:` leads to an error page. I also changed the link to the file directly.