### PR TITLE
fix issues in the example code

### DIFF
--- a/examples/datasets/dnerf_synthetic.py
+++ b/examples/datasets/dnerf_synthetic.py
@@ -176,7 +176,7 @@ class SubjectLoader(torch.utils.data.Dataset):
                     device=self.images.device,
                 )
             else:
-                image_id = [index]
+                image_id = [index] * num_rays
             x = torch.randint(
                 0, self.WIDTH, size=(num_rays,), device=self.images.device
             )

--- a/examples/datasets/nerf_360_v2.py
+++ b/examples/datasets/nerf_360_v2.py
@@ -306,7 +306,7 @@ class SubjectLoader(torch.utils.data.Dataset):
                     device=self.images.device,
                 )
             else:
-                image_id = [index]
+                image_id = [index] * num_rays
             x = torch.randint(
                 0, self.width, size=(num_rays,), device=self.images.device
             )

--- a/examples/datasets/nerf_synthetic.py
+++ b/examples/datasets/nerf_synthetic.py
@@ -174,7 +174,7 @@ class SubjectLoader(torch.utils.data.Dataset):
                     device=self.images.device,
                 )
             else:
-                image_id = [index]
+                image_id = [index] * num_rays
             x = torch.randint(
                 0, self.WIDTH, size=(num_rays,), device=self.images.device
             )


### PR DESCRIPTION
Fix the issue when `batch_over_images` in the data loader is set to `False`, running the example code will result in an error.
According to the issue #202.