### PR TITLE
Fixed grid traversal with near and far planes

### DIFF
--- a/nerfacc/cuda/csrc/grid.cu
+++ b/nerfacc/cuda/csrc/grid.cu
@@ -140,6 +140,7 @@ __global__ void traverse_grids_kernel(
             const int3 overflow_index = final_index + step_index;
             while (true) {
                 float t_traverse = min(tdist.x, min(tdist.y, tdist.z));
+                t_traverse = fminf(t_traverse, this_tmax);
                 int64_t cell_id = (
                     current_index.x * resolution.y * resolution.z
                     + current_index.y * resolution.z

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -81,18 +81,18 @@ def test_traverse_grids_with_near_far_planes():
 
     near_planes = torch.tensor([1.2], device=device)
     far_planes = torch.tensor([1.5], device=device)
-    eps = 1e-7
+    step_size = 0.05
 
     intervals, samples = traverse_grids(
         rays_o=rays_o, 
         rays_d=rays_d, 
         binaries=binaries, 
         aabbs=aabbs, 
-        step_size=0.05, 
+        step_size=step_size, 
         near_planes=near_planes, 
         far_planes=far_planes)
-    assert (intervals.vals >= (near_planes - eps)).all()
-    assert (intervals.vals <= (far_planes + eps)).all()
+    assert (intervals.vals >= (near_planes - step_size / 2)).all()
+    assert (intervals.vals <= (far_planes + step_size / 2)).all()
     
     
 if __name__ == "__main__":

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -72,29 +72,30 @@ def test_traverse_grids():
 def test_traverse_grids_with_near_far_planes():
     from nerfacc.grid import traverse_grids
 
-    rays_o = torch.tensor([[-1., 0., 0.]], device=device)
-    rays_d = torch.tensor([[1., 0.01, 0.01]], device=device)
+    rays_o = torch.tensor([[-1.0, 0.0, 0.0]], device=device)
+    rays_d = torch.tensor([[1.0, 0.01, 0.01]], device=device)
     rays_d = rays_d / rays_d.norm(dim=-1, keepdim=True)
 
     binaries = torch.ones((1, 1, 1, 1), dtype=torch.bool, device=device)
-    aabbs = torch.tensor([[0., 0., 0., 1., 1., 1.]], device=device)
+    aabbs = torch.tensor([[0.0, 0.0, 0.0, 1.0, 1.0, 1.0]], device=device)
 
     near_planes = torch.tensor([1.2], device=device)
     far_planes = torch.tensor([1.5], device=device)
     step_size = 0.05
 
     intervals, samples = traverse_grids(
-        rays_o=rays_o, 
-        rays_d=rays_d, 
-        binaries=binaries, 
-        aabbs=aabbs, 
-        step_size=step_size, 
-        near_planes=near_planes, 
-        far_planes=far_planes)
+        rays_o=rays_o,
+        rays_d=rays_d,
+        binaries=binaries,
+        aabbs=aabbs,
+        step_size=step_size,
+        near_planes=near_planes,
+        far_planes=far_planes,
+    )
     assert (intervals.vals >= (near_planes - step_size / 2)).all()
     assert (intervals.vals <= (far_planes + step_size / 2)).all()
-    
-    
+
+
 if __name__ == "__main__":
     test_ray_aabb_intersect()
     test_traverse_grids()


### PR DESCRIPTION
This PR fixes wrong points sampling behind the far_plane, as described in #201 