### PR TITLE
Per-ray minimum and maximum distances in sampling method

### DIFF
--- a/nerfacc/cuda/csrc/grid.cu
+++ b/nerfacc/cuda/csrc/grid.cu
@@ -140,6 +140,7 @@ __global__ void traverse_grids_kernel(
             const int3 overflow_index = final_index + step_index;
             while (true) {
                 float t_traverse = min(tdist.x, min(tdist.y, tdist.z));
+                t_traverse = fminf(t_traverse, this_tmax);
                 int64_t cell_id = (
                     current_index.x * resolution.y * resolution.z
                     + current_index.y * resolution.z

--- a/nerfacc/estimators/occ_grid.py
+++ b/nerfacc/estimators/occ_grid.py
@@ -93,8 +93,8 @@ class OccGridEstimator(AbstractEstimator):
         alpha_fn: Optional[Callable] = None,
         near_plane: float = 0.0,
         far_plane: float = 1e10,
-        t_min: Optional[Tensor] = None, # [n_rays]
-        t_max: Optional[Tensor] = None, # [n_rays]
+        t_min: Optional[Tensor] = None,  # [n_rays]
+        t_max: Optional[Tensor] = None,  # [n_rays]
         # rendering options
         render_step_size: float = 1e-3,
         early_stop_eps: float = 1e-4,
@@ -122,7 +122,7 @@ class OccGridEstimator(AbstractEstimator):
                 You should only provide either `sigma_fn` or `alpha_fn`.
             near_plane: Optional. Near plane distance. Default: 0.0.
             far_plane: Optional. Far plane distance. Default: 1e10.
-            t_min: Optional. Per-ray minimum distance. Tensor with shape (n_rays). 
+            t_min: Optional. Per-ray minimum distance. Tensor with shape (n_rays).
                 If profided, the marching will start from maximum of t_min and near_plane.
             t_max: Optional. Per-ray maximum distance. Tensor with shape (n_rays).
                 If profided, the marching will stop by minimum of t_max and far_plane.

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -81,18 +81,18 @@ def test_traverse_grids_with_near_far_planes():
 
     near_planes = torch.tensor([1.2], device=device)
     far_planes = torch.tensor([1.5], device=device)
-    eps = 1e-7
+    step_size = 0.05
 
     intervals, samples = traverse_grids(
         rays_o=rays_o, 
         rays_d=rays_d, 
         binaries=binaries, 
         aabbs=aabbs, 
-        step_size=0.05, 
+        step_size=step_size, 
         near_planes=near_planes, 
         far_planes=far_planes)
-    assert (intervals.vals >= (near_planes - eps)).all()
-    assert (intervals.vals <= (far_planes + eps)).all()
+    assert (intervals.vals >= (near_planes - step_size / 2)).all()
+    assert (intervals.vals <= (far_planes + step_size / 2)).all()
     
     
 if __name__ == "__main__":

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -72,29 +72,30 @@ def test_traverse_grids():
 def test_traverse_grids_with_near_far_planes():
     from nerfacc.grid import traverse_grids
 
-    rays_o = torch.tensor([[-1., 0., 0.]], device=device)
-    rays_d = torch.tensor([[1., 0.01, 0.01]], device=device)
+    rays_o = torch.tensor([[-1.0, 0.0, 0.0]], device=device)
+    rays_d = torch.tensor([[1.0, 0.01, 0.01]], device=device)
     rays_d = rays_d / rays_d.norm(dim=-1, keepdim=True)
 
     binaries = torch.ones((1, 1, 1, 1), dtype=torch.bool, device=device)
-    aabbs = torch.tensor([[0., 0., 0., 1., 1., 1.]], device=device)
+    aabbs = torch.tensor([[0.0, 0.0, 0.0, 1.0, 1.0, 1.0]], device=device)
 
     near_planes = torch.tensor([1.2], device=device)
     far_planes = torch.tensor([1.5], device=device)
     step_size = 0.05
 
     intervals, samples = traverse_grids(
-        rays_o=rays_o, 
-        rays_d=rays_d, 
-        binaries=binaries, 
-        aabbs=aabbs, 
-        step_size=step_size, 
-        near_planes=near_planes, 
-        far_planes=far_planes)
+        rays_o=rays_o,
+        rays_d=rays_d,
+        binaries=binaries,
+        aabbs=aabbs,
+        step_size=step_size,
+        near_planes=near_planes,
+        far_planes=far_planes,
+    )
     assert (intervals.vals >= (near_planes - step_size / 2)).all()
     assert (intervals.vals <= (far_planes + step_size / 2)).all()
-    
-    
+
+
 if __name__ == "__main__":
     test_ray_aabb_intersect()
     test_traverse_grids()

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -113,14 +113,15 @@ def test_sampling_with_min_max_distances():
     rays_d = rays_d / rays_d.norm(dim=-1, keepdim=True)
 
     aabb = torch.tensor([-1.0, -1.0, -1.0, 1.0, 1.0, 1.0], device=device)
-    binaries = torch.rand((levels, resolution, resolution, resolution), device=device) > 0.5
+    binaries = (
+        torch.rand((levels, resolution, resolution, resolution), device=device)
+        > 0.5
+    )
     t_min = torch.rand((n_rays,), device=device)
     t_max = t_min + torch.rand((n_rays,), device=device)
 
     grid_estimator = OccGridEstimator(
-        roi_aabb=aabb,
-        resolution=resolution,
-        levels=levels
+        roi_aabb=aabb, resolution=resolution, levels=levels
     )
 
     grid_estimator.binaries = binaries
@@ -132,7 +133,7 @@ def test_sampling_with_min_max_distances():
         far_plane=far_plane,
         t_min=t_min,
         t_max=t_max,
-        render_step_size=render_step_size
+        render_step_size=render_step_size,
     )
 
     assert (t_starts >= (t_min[ray_indices] - render_step_size / 2)).all()


### PR DESCRIPTION
I found quite useful in previous versions of nerfacc `t_min` and `t_max` in `ray_marching` function as it gave a possibility to bring some prior information into sampling procedure. So with this PR I suggest to add these arguments into `sampling` method. 
Test added to prove the correctness of the implementation.